### PR TITLE
getting the image extension and updating tests

### DIFF
--- a/src/aind_smartspim_data_transformation/io/readers.py
+++ b/src/aind_smartspim_data_transformation/io/readers.py
@@ -109,9 +109,9 @@ class ImageReader(ABC):
         self.__data_path = new_data_path
 
 
-class PngReader(ImageReader):
+class PngTiffReader(ImageReader):
     """
-    PngReader class
+    PngTiffReader class
     """
 
     def __init__(self, data_path: PathLike) -> None:

--- a/tests/test_io/test_readers.py
+++ b/tests/test_io/test_readers.py
@@ -4,7 +4,7 @@ import os
 import unittest
 from pathlib import Path
 
-from aind_smartspim_data_transformation.io.readers import PngReader
+from aind_smartspim_data_transformation.io.readers import PngTiffReader
 
 RESOURCES_DIR = (
     Path(os.path.dirname(os.path.realpath(__file__))) / ".." / "resources"
@@ -21,13 +21,13 @@ STACK_DIR = (
 )
 
 
-class TestPngReader(unittest.TestCase):
-    """Tests methods in PngReader class"""
+class TestPngTiffReader(unittest.TestCase):
+    """Tests methods in PngTiffReader class"""
 
     @classmethod
     def setUpClass(cls):
         """Sets up class with common reader"""
-        cls.reader = PngReader(STACK_DIR)
+        cls.reader = PngTiffReader(STACK_DIR)
 
     def test_shape(self):
         """Tests shape method"""
@@ -45,7 +45,7 @@ class TestPngReader(unittest.TestCase):
 
     def test_data_path_setter(self):
         """Tests data_path_setter"""
-        reader = PngReader(STACK_DIR)
+        reader = PngTiffReader(STACK_DIR)
         reader.data_path = "tests"
         self.assertEqual("tests", reader.data_path)
 

--- a/tests/test_smartspim_job.py
+++ b/tests/test_smartspim_job.py
@@ -98,7 +98,7 @@ class SmartspimCompressionTest(unittest.TestCase):
         """Tests _get_compressor method returns None if no config set"""
 
         job_settings = SmartspimJobSettings.model_construct(
-            compressor_name="foo"
+            input_source="", output_directory="", compressor_name="foo"
         )
         job = SmartspimCompressionJob(job_settings=job_settings)
         compressor = job._get_compressor()


### PR DESCRIPTION
Recently, we got a dataset from UW which is in Tiff format. My PngReader class is able to handle tiffs as well but I was used only for Pngs. I updated the class name and the tests to handle tiffs.

This is kind of high priority and we'd like to get this deployed so we could use the transfer service @jtyoung84 .

Thanks!