### PR TITLE
Read voxel resolution from aind-data-schema v2 acquisition format

### DIFF
--- a/src/aind_smartspim_data_transformation/__init__.py
+++ b/src/aind_smartspim_data_transformation/__init__.py
@@ -1,3 +1,3 @@
 """Init package"""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/src/aind_smartspim_data_transformation/compress/png_to_zarr.py
+++ b/src/aind_smartspim_data_transformation/compress/png_to_zarr.py
@@ -542,8 +542,7 @@ def safe_create_zarr_group(
             )
         lock_path = os.path.join(store.path, path, ".zgroup.lock")
         lock_cm = FileLock(
-            lock_path,
-            timeout=10  # 10 second timeout on obtaining filelock
+            lock_path, timeout=10  # 10 second timeout on obtaining filelock
         )
     else:
         lock_cm = nullcontext()

--- a/src/aind_smartspim_data_transformation/helpers.py
+++ b/src/aind_smartspim_data_transformation/helpers.py
@@ -1,0 +1,109 @@
+"""
+Utility functions for the radial correction step
+"""
+
+import json
+import os
+from typing import List
+
+
+def read_json_as_dict(filepath: str) -> dict:
+    """
+    Reads a json as dictionary.
+
+    Parameters
+    ------------------------
+
+    filepath: PathLike
+        Path where the json is located.
+
+    Returns
+    ------------------------
+
+    dict:
+        Dictionary with the data the json has.
+
+    """
+
+    dictionary = {}
+
+    if os.path.exists(filepath):
+        with open(filepath) as json_file:
+            dictionary = json.load(json_file)
+
+    return dictionary
+
+
+def _get_voxel_resolution_v1(acquisition_config: dict) -> List[float]:
+    """
+    Get the voxel resolution from an acquisition.json file.
+
+    Parameters
+    ----------
+    acquisition_config: Dict
+        Dictionary with the acquisition.json data.
+    Returns
+    -------
+    List[float]
+        Voxel resolution in the format [z, y, x].
+    """
+
+    if not acquisition_config:
+        raise ValueError("acquisition.json file is empty or invalid.")
+
+    # Grabbing a tile with metadata from acquisition - we assume all
+    # dataset was acquired with the same resolution
+    tile_coord_transforms = acquisition_config["tiles"][0][
+        "coordinate_transformations"
+    ]
+
+    scale_transform = [
+        x["scale"] for x in tile_coord_transforms if x["type"] == "scale"
+    ][0]
+
+    x = float(scale_transform[0])
+    y = float(scale_transform[1])
+    z = float(scale_transform[2])
+
+    return [z, y, x]
+
+
+def _get_voxel_resolution_v2(acquisition_config: dict) -> List[float]:
+    """
+    Get the voxel resolution from an acquisition.json in
+    aind-data-schema v2 format.
+
+    Parameters
+    ----------
+    acquisition_config: Dict
+        Dictionary with the acquisition.json data.
+
+    Returns
+    -------
+    List[float]
+        Voxel resolution in the format [z, y, x].
+    """
+    try:
+        data_stream = acquisition_config.get("data_streams", [])[0]
+        configuration = data_stream.get("configurations", [])[0]
+        image = configuration.get("images", [])[0]
+        image_to_acquisition_transform = image[
+            "image_to_acquisition_transform"
+        ]
+    except (IndexError, AttributeError, KeyError) as e:
+        raise ValueError(
+            "acquisition_config structure is invalid or missing "
+            "required fields"
+        ) from e
+
+    scale_transform = [
+        x["scale"]
+        for x in image_to_acquisition_transform
+        if x["object_type"] == "Scale"
+    ][0]
+
+    x = float(scale_transform[0])
+    y = float(scale_transform[1])
+    z = float(scale_transform[2])
+
+    return [z, y, x]

--- a/src/aind_smartspim_data_transformation/smartspim_job.py
+++ b/src/aind_smartspim_data_transformation/smartspim_job.py
@@ -64,7 +64,16 @@ class SmartspimCompressionJob(GenericEtl[SmartspimJobSettings]):
 
     @staticmethod
     def _get_voxel_resolution(acquisition_path: Path) -> List[float]:
-        """Get the voxel resolution from an acquisition.json file."""
+        """Get the voxel resolution from an acquisition.json file.
+
+        Targets aind-data-schema v2 acquisition metadata, where the flat
+        ``tiles`` list was replaced by
+        ``data_streams -> DataStream -> ImagingConfig -> images``. Each
+        ``ImageSPIM`` carries an ``image_to_acquisition_transform`` list that
+        holds a ``Scale`` transform with the ``[x, y, z]`` voxel size in
+        microns. We assume the whole dataset was acquired at the same
+        resolution and read the first image we find.
+        """
 
         if not acquisition_path.is_file():
             raise FileNotFoundError(
@@ -73,14 +82,27 @@ class SmartspimCompressionJob(GenericEtl[SmartspimJobSettings]):
 
         acquisition_config = utils.read_json_as_dict(acquisition_path)
 
-        # Grabbing a tile with metadata from acquisition - we assume all
-        # dataset was acquired with the same resolution
-        tile_coord_transforms = acquisition_config["tiles"][0][
-            "coordinate_transformations"
-        ]
+        # Find the first ImageSPIM across all data streams / imaging configs.
+        # We assume all tiles share the same resolution.
+        image = None
+        for data_stream in acquisition_config.get("data_streams", []):
+            for config in data_stream.get("configurations", []):
+                images = config.get("images")
+                if images:
+                    image = images[0]
+                    break
+            if image is not None:
+                break
 
+        if image is None:
+            raise ValueError(
+                "No image with a coordinate transform found in acquisition "
+                f"file: {acquisition_path}"
+            )
+
+        transforms = image["image_to_acquisition_transform"]
         scale_transform = [
-            x["scale"] for x in tile_coord_transforms if x["type"] == "scale"
+            t["scale"] for t in transforms if t.get("object_type") == "Scale"
         ][0]
 
         x = float(scale_transform[0])

--- a/src/aind_smartspim_data_transformation/smartspim_job.py
+++ b/src/aind_smartspim_data_transformation/smartspim_job.py
@@ -9,16 +9,16 @@ from time import time
 from typing import Any, List, Optional
 
 from aind_data_transformation.core import GenericEtl, JobResponse, get_parser
-from aind_data_transormation.helpers import (
-    _get_voxel_resolution_v1,
-    _get_voxel_resolution_v2,
-    read_json_as_dict,
-)
 from numcodecs.blosc import Blosc
 from packaging import version
 
 from aind_smartspim_data_transformation.compress.png_to_zarr import (
     smartspim_channel_zarr_writer,
+)
+from aind_smartspim_data_transformation.helpers import (
+    _get_voxel_resolution_v1,
+    _get_voxel_resolution_v2,
+    read_json_as_dict,
 )
 from aind_smartspim_data_transformation.io import utils
 from aind_smartspim_data_transformation.io.readers import PngTiffReader
@@ -69,7 +69,7 @@ class SmartspimCompressionJob(GenericEtl[SmartspimJobSettings]):
         )
 
     @staticmethod
-    def get_voxel_resolution(acquisition_path: Path) -> List[float]:
+    def _get_voxel_resolution(acquisition_path: Path) -> List[float]:
         """
         Get the voxel resolution from an acquisition.json file.
 

--- a/src/aind_smartspim_data_transformation/smartspim_job.py
+++ b/src/aind_smartspim_data_transformation/smartspim_job.py
@@ -66,13 +66,23 @@ class SmartspimCompressionJob(GenericEtl[SmartspimJobSettings]):
     def _get_voxel_resolution(acquisition_path: Path) -> List[float]:
         """Get the voxel resolution from an acquisition.json file.
 
-        Targets aind-data-schema v2 acquisition metadata, where the flat
-        ``tiles`` list was replaced by
-        ``data_streams -> DataStream -> ImagingConfig -> images``. Each
-        ``ImageSPIM`` carries an ``image_to_acquisition_transform`` list that
-        holds a ``Scale`` transform with the ``[x, y, z]`` voxel size in
-        microns. We assume the whole dataset was acquired at the same
-        resolution and read the first image we find.
+        Supports both acquisition schema layouts to cover the transition to
+        aind-data-schema v2, dispatching on the file's structure:
+
+        * **aind-data-schema v2** (current): the flat ``tiles`` list was
+          replaced by ``data_streams -> DataStream -> ImagingConfig ->
+          images``, where each ``ImageSPIM`` carries an
+          ``image_to_acquisition_transform`` holding a ``Scale`` transform.
+        * **legacy** (pre-v2): a flat ``tiles`` list whose entries hold
+          ``coordinate_transformations`` with a ``scale`` entry.
+
+        Dispatch is on structure (presence of ``data_streams`` vs ``tiles``)
+        rather than the ``schema_version`` string, because that directly tests
+        the layout we are about to read; ``schema_version`` is logged for
+        traceability. In both layouts the ``Scale`` is ``[x, y, z]`` in
+        microns; we assume the whole dataset was acquired at the same
+        resolution and read the first tile/image we find, returning
+        ``[z, y, x]``.
         """
 
         if not acquisition_path.is_file():
@@ -81,9 +91,47 @@ class SmartspimCompressionJob(GenericEtl[SmartspimJobSettings]):
             )
 
         acquisition_config = utils.read_json_as_dict(acquisition_path)
+        schema_version = acquisition_config.get("schema_version", "unknown")
 
-        # Find the first ImageSPIM across all data streams / imaging configs.
-        # We assume all tiles share the same resolution.
+        if "data_streams" in acquisition_config:
+            logging.info(
+                f"Reading v2 acquisition (schema_version={schema_version}): "
+                f"{acquisition_path}"
+            )
+            scale_transform = SmartspimCompressionJob._get_scale_v2(
+                acquisition_config, acquisition_path
+            )
+        elif "tiles" in acquisition_config:
+            logging.info(
+                "Reading legacy acquisition "
+                f"(schema_version={schema_version}): {acquisition_path}"
+            )
+            scale_transform = SmartspimCompressionJob._get_scale_legacy(
+                acquisition_config
+            )
+        else:
+            raise ValueError(
+                "Unrecognized acquisition schema (no 'data_streams' or "
+                f"'tiles' key, schema_version={schema_version}) in file: "
+                f"{acquisition_path}"
+            )
+
+        x = float(scale_transform[0])
+        y = float(scale_transform[1])
+        z = float(scale_transform[2])
+
+        return [z, y, x]
+
+    @staticmethod
+    def _get_scale_v2(
+        acquisition_config: dict, acquisition_path: Path
+    ) -> List[float]:
+        """Read the ``[x, y, z]`` scale from a v2 acquisition config.
+
+        Walks ``data_streams -> configurations -> images`` and returns the
+        ``Scale`` transform of the first ``ImageSPIM`` found. We assume all
+        tiles share the same resolution.
+        """
         image = None
         for data_stream in acquisition_config.get("data_streams", []):
             for config in data_stream.get("configurations", []):
@@ -101,15 +149,23 @@ class SmartspimCompressionJob(GenericEtl[SmartspimJobSettings]):
             )
 
         transforms = image["image_to_acquisition_transform"]
-        scale_transform = [
+        return [
             t["scale"] for t in transforms if t.get("object_type") == "Scale"
         ][0]
 
-        x = float(scale_transform[0])
-        y = float(scale_transform[1])
-        z = float(scale_transform[2])
-
-        return [z, y, x]
+    @staticmethod
+    def _get_scale_legacy(acquisition_config: dict) -> List[float]:
+        """Read the ``[x, y, z]`` scale from a legacy (pre-v2) acquisition
+        config, using the first tile's ``coordinate_transformations``. We
+        assume all tiles share the same resolution."""
+        tile_coord_transforms = acquisition_config["tiles"][0][
+            "coordinate_transformations"
+        ]
+        return [
+            t["scale"]
+            for t in tile_coord_transforms
+            if t["type"] == "scale"
+        ][0]
 
     def _get_compressor(self) -> Optional[Blosc]:
         """

--- a/src/aind_smartspim_data_transformation/smartspim_job.py
+++ b/src/aind_smartspim_data_transformation/smartspim_job.py
@@ -9,7 +9,13 @@ from time import time
 from typing import Any, List, Optional
 
 from aind_data_transformation.core import GenericEtl, JobResponse, get_parser
+from aind_data_transormation.helpers import (
+    _get_voxel_resolution_v1,
+    _get_voxel_resolution_v2,
+    read_json_as_dict,
+)
 from numcodecs.blosc import Blosc
+from packaging import version
 
 from aind_smartspim_data_transformation.compress.png_to_zarr import (
     smartspim_channel_zarr_writer,
@@ -63,109 +69,33 @@ class SmartspimCompressionJob(GenericEtl[SmartspimJobSettings]):
         )
 
     @staticmethod
-    def _get_voxel_resolution(acquisition_path: Path) -> List[float]:
-        """Get the voxel resolution from an acquisition.json file.
-
-        Supports both acquisition schema layouts to cover the transition to
-        aind-data-schema v2, dispatching on the file's structure:
-
-        * **aind-data-schema v2** (current): the flat ``tiles`` list was
-          replaced by ``data_streams -> DataStream -> ImagingConfig ->
-          images``, where each ``ImageSPIM`` carries an
-          ``image_to_acquisition_transform`` holding a ``Scale`` transform.
-        * **legacy** (pre-v2): a flat ``tiles`` list whose entries hold
-          ``coordinate_transformations`` with a ``scale`` entry.
-
-        Dispatch is on structure (presence of ``data_streams`` vs ``tiles``)
-        rather than the ``schema_version`` string, because that directly tests
-        the layout we are about to read; ``schema_version`` is logged for
-        traceability. In both layouts the ``Scale`` is ``[x, y, z]`` in
-        microns; we assume the whole dataset was acquired at the same
-        resolution and read the first tile/image we find, returning
-        ``[z, y, x]``.
+    def get_voxel_resolution(acquisition_path: Path) -> List[float]:
         """
+        Get the voxel resolution from an acquisition.json file.
 
-        if not acquisition_path.is_file():
+        Parameters
+        ----------
+        acquisition_path: Path
+            Path to the acquisition.json file.
+        Returns
+        -------
+        List[float]
+            Voxel resolution in the format [z, y, x].
+        """
+        if not Path(acquisition_path).is_file():
             raise FileNotFoundError(
                 f"acquisition.json file not found at: {acquisition_path}"
             )
 
-        acquisition_config = utils.read_json_as_dict(acquisition_path)
-        schema_version = acquisition_config.get("schema_version", "unknown")
+        acquisition_config = read_json_as_dict(str(acquisition_path))
 
-        if "data_streams" in acquisition_config:
-            logging.info(
-                f"Reading v2 acquisition (schema_version={schema_version}): "
-                f"{acquisition_path}"
-            )
-            scale_transform = SmartspimCompressionJob._get_scale_v2(
-                acquisition_config, acquisition_path
-            )
-        elif "tiles" in acquisition_config:
-            logging.info(
-                "Reading legacy acquisition "
-                f"(schema_version={schema_version}): {acquisition_path}"
-            )
-            scale_transform = SmartspimCompressionJob._get_scale_legacy(
-                acquisition_config
-            )
+        schema_version = acquisition_config.get("schema_version")
+        print(f"Schema version: {schema_version}")
+
+        if version.parse(schema_version) >= version.parse("2.0.0"):
+            return _get_voxel_resolution_v2(acquisition_config)
         else:
-            raise ValueError(
-                "Unrecognized acquisition schema (no 'data_streams' or "
-                f"'tiles' key, schema_version={schema_version}) in file: "
-                f"{acquisition_path}"
-            )
-
-        x = float(scale_transform[0])
-        y = float(scale_transform[1])
-        z = float(scale_transform[2])
-
-        return [z, y, x]
-
-    @staticmethod
-    def _get_scale_v2(
-        acquisition_config: dict, acquisition_path: Path
-    ) -> List[float]:
-        """Read the ``[x, y, z]`` scale from a v2 acquisition config.
-
-        Walks ``data_streams -> configurations -> images`` and returns the
-        ``Scale`` transform of the first ``ImageSPIM`` found. We assume all
-        tiles share the same resolution.
-        """
-        image = None
-        for data_stream in acquisition_config.get("data_streams", []):
-            for config in data_stream.get("configurations", []):
-                images = config.get("images")
-                if images:
-                    image = images[0]
-                    break
-            if image is not None:
-                break
-
-        if image is None:
-            raise ValueError(
-                "No image with a coordinate transform found in acquisition "
-                f"file: {acquisition_path}"
-            )
-
-        transforms = image["image_to_acquisition_transform"]
-        return [
-            t["scale"] for t in transforms if t.get("object_type") == "Scale"
-        ][0]
-
-    @staticmethod
-    def _get_scale_legacy(acquisition_config: dict) -> List[float]:
-        """Read the ``[x, y, z]`` scale from a legacy (pre-v2) acquisition
-        config, using the first tile's ``coordinate_transformations``. We
-        assume all tiles share the same resolution."""
-        tile_coord_transforms = acquisition_config["tiles"][0][
-            "coordinate_transformations"
-        ]
-        return [
-            t["scale"]
-            for t in tile_coord_transforms
-            if t["type"] == "scale"
-        ][0]
+            return _get_voxel_resolution_v1(acquisition_config)
 
     def _get_compressor(self) -> Optional[Blosc]:
         """

--- a/tests/resources/SmartSPIM_000000_2024-06-05_07-56-54/acquisition.json
+++ b/tests/resources/SmartSPIM_000000_2024-06-05_07-56-54/acquisition.json
@@ -1,2352 +1,408 @@
 {
-   "active_objectives": null,
-   "axes": [
-      {
-         "dimension": 2,
-         "direction": "Left_to_right",
-         "name": "X",
-         "unit": "micrometer"
-      },
-      {
-         "dimension": 1,
-         "direction": "Posterior_to_anterior",
-         "name": "Y",
-         "unit": "micrometer"
-      },
-      {
-         "dimension": 0,
-         "direction": "Superior_to_inferior",
-         "name": "Z",
-         "unit": "micrometer"
-      }
-   ],
-   "chamber_immersion": {
-      "medium": "Cargille 1.52",
-      "refractive_index": 1.522
-   },
-   "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/imaging/acquisition.py",
-   "experimenter_full_name": [
+   "object_type": "Acquisition",
+   "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/acquisition.py",
+   "schema_version": "2.5.1",
+   "protocol_id": null,
+   "subject_id": "000000",
+   "specimen_id": "000000",
+   "acquisition_start_time": "2024-06-05T07:56:54-07:00",
+   "acquisition_start_tz": -7,
+   "acquisition_end_time": "2024-06-05T12:00:00-07:00",
+   "experimenters": [
       "Erica Peterson"
    ],
-   "external_storage_directory": "",
+   "ethics_review_id": null,
    "instrument_id": "SmartSPIM3-2",
-   "local_storage_directory": "D:/SmartSPIM_Data",
+   "acquisition_type": "SmartSPIM",
    "notes": null,
-   "processing_steps": null,
-   "sample_immersion": {
-      "medium": "EasyIndex",
-      "refractive_index": 1.5199
-   },
-   "schema_version": "0.4.6",
-   "session_end_time": "2023-10-19T12:00:55",
-   "session_start_time": "2023-10-18T20:30:30",
-   "session_type": null,
-   "specimen_id": "",
-   "subject_id": "695464",
-   "tiles": [
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  47132.0,
-                  70149.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/471320.0/471320.0_701490.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  47132.0,
-                  70149.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/471320.0/471320.0_701490.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  56852.0,
-                  70149.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/568520.0/568520.0_701490.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  56852.0,
-                  70149.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/568520.0/568520.0_701490.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  47132.0,
-                  72741.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/471320.0/471320.0_727410.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  47132.0,
-                  72741.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/471320.0/471320.0_727410.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  47132.0,
-                  72741.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/471320.0/471320.0_727410.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  50372.0,
-                  72741.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/503720.0/503720.0_727410.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  50372.0,
-                  72741.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/503720.0/503720.0_727410.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  50372.0,
-                  72741.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/503720.0/503720.0_727410.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  53612.0,
-                  72741.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/536120.0/536120.0_727410.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  53612.0,
-                  72741.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/536120.0/536120.0_727410.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  47132.0,
-                  70149.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/471320.0/471320.0_701490.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  53612.0,
-                  72741.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/536120.0/536120.0_727410.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  56852.0,
-                  72741.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/568520.0/568520.0_727410.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  56852.0,
-                  72741.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/568520.0/568520.0_727410.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  56852.0,
-                  72741.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/568520.0/568520.0_727410.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  47132.0,
-                  75333.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/471320.0/471320.0_753330.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  47132.0,
-                  75333.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/471320.0/471320.0_753330.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  47132.0,
-                  75333.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/471320.0/471320.0_753330.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  50372.0,
-                  75333.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/503720.0/503720.0_753330.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  50372.0,
-                  75333.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/503720.0/503720.0_753330.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  50372.0,
-                  75333.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/503720.0/503720.0_753330.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  50372.0,
-                  70149.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/503720.0/503720.0_701490.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  53612.0,
-                  75333.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/536120.0/536120.0_753330.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  53612.0,
-                  75333.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/536120.0/536120.0_753330.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  53612.0,
-                  75333.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/536120.0/536120.0_753330.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  56852.0,
-                  75333.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/568520.0/568520.0_753330.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  56852.0,
-                  75333.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/568520.0/568520.0_753330.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  56852.0,
-                  75333.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/568520.0/568520.0_753330.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  47132.0,
-                  77925.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/471320.0/471320.0_779250.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  47132.0,
-                  77925.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/471320.0/471320.0_779250.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  47132.0,
-                  77925.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/471320.0/471320.0_779250.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  50372.0,
-                  77925.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/503720.0/503720.0_779250.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  50372.0,
-                  70149.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/503720.0/503720.0_701490.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  50372.0,
-                  77925.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/503720.0/503720.0_779250.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  50372.0,
-                  77925.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/503720.0/503720.0_779250.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  53612.0,
-                  77925.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/536120.0/536120.0_779250.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  53612.0,
-                  77925.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/536120.0/536120.0_779250.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  53612.0,
-                  77925.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/536120.0/536120.0_779250.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  56852.0,
-                  77925.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/568520.0/568520.0_779250.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  56852.0,
-                  77925.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/568520.0/568520.0_779250.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  56852.0,
-                  77925.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/568520.0/568520.0_779250.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  47132.0,
-                  80517.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/471320.0/471320.0_805170.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  47132.0,
-                  80517.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/471320.0/471320.0_805170.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  50372.0,
-                  70149.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/503720.0/503720.0_701490.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  47132.0,
-                  80517.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/471320.0/471320.0_805170.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  50372.0,
-                  80517.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/503720.0/503720.0_805170.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  50372.0,
-                  80517.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/503720.0/503720.0_805170.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  50372.0,
-                  80517.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/503720.0/503720.0_805170.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  53612.0,
-                  80517.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/536120.0/536120.0_805170.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  53612.0,
-                  80517.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/536120.0/536120.0_805170.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  53612.0,
-                  80517.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/536120.0/536120.0_805170.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  56852.0,
-                  80517.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/568520.0/568520.0_805170.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  56852.0,
-                  80517.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/568520.0/568520.0_805170.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  56852.0,
-                  80517.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/568520.0/568520.0_805170.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  53612.0,
-                  70149.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/536120.0/536120.0_701490.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  47132.0,
-                  83109.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/471320.0/471320.0_831090.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  47132.0,
-                  83109.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/471320.0/471320.0_831090.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  47132.0,
-                  83109.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/471320.0/471320.0_831090.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  50372.0,
-                  83109.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/503720.0/503720.0_831090.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  50372.0,
-                  83109.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/503720.0/503720.0_831090.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  50372.0,
-                  83109.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/503720.0/503720.0_831090.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  53612.0,
-                  83109.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/536120.0/536120.0_831090.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  53612.0,
-                  83109.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/536120.0/536120.0_831090.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  53612.0,
-                  83109.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/536120.0/536120.0_831090.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  56852.0,
-                  83109.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/568520.0/568520.0_831090.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  53612.0,
-                  70149.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/536120.0/536120.0_701490.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "561",
-            "filter_wheel_index": 1,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 561,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  56852.0,
-                  83109.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_561_Em_600/568520.0/568520.0_831090.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  56852.0,
-                  83109.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/568520.0/568520.0_831090.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "639",
-            "filter_wheel_index": 2,
-            "laser_power": 100.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 639,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  53612.0,
-                  70149.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_639_Em_680/536120.0/536120.0_701490.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
-      },
-      {
-         "channel": {
-            "channel_name": "488",
-            "filter_wheel_index": 0,
-            "laser_power": 75.0,
-            "laser_power_unit": "milliwatt",
-            "laser_wavelength": 488,
-            "laser_wavelength_unit": "nanometer"
-         },
-         "coordinate_transformations": [
-            {
-               "translation": [
-                  56852.0,
-                  70149.0,
-                  170.7
-               ],
-               "type": "translation"
-            },
-            {
-               "scale": [
-                  1.8,
-                  1.8,
-                  2.0
-               ],
-               "type": "scale"
-            }
-         ],
-         "file_name": "Ex_488_Em_525/568520.0/568520.0_701490.0/",
-         "imaging_angle": 0,
-         "imaging_angle_unit": "degree",
-         "notes": "\nLaser power is in percentage of total, it needs calibration"
+   "coordinate_system": null,
+   "calibrations": [],
+   "maintenance": [],
+   "data_streams": [
+      {
+         "object_type": "Data stream",
+         "stream_start_time": "2024-06-05T07:56:54-07:00",
+         "stream_end_time": "2024-06-05T12:00:00-07:00",
+         "modalities": [
+            {
+               "name": "Selective plane illumination microscopy",
+               "abbreviation": "SPIM"
+            }
+         ],
+         "code": null,
+         "notes": "Laser power units are recorded per channel in LaserConfig.power_unit (mW when calibrated, otherwise percent).",
+         "active_devices": [
+            "Camera",
+            "Em_469",
+            "Em_600",
+            "Ex_445",
+            "Ex_561",
+            "Sample Chamber"
+         ],
+         "configurations": [
+            {
+               "object_type": "Imaging config",
+               "device_name": "SmartSPIM3-2",
+               "channels": [
+                  {
+                     "object_type": "Channel",
+                     "channel_name": "Ex_445_Em_469_left",
+                     "intended_measurement": null,
+                     "detector": {
+                        "object_type": "Detector config",
+                        "device_name": "Camera",
+                        "exposure_time": null,
+                        "exposure_time_unit": "millisecond",
+                        "trigger_type": "Internal",
+                        "compression": null,
+                        "crop_offset_x": null,
+                        "crop_offset_y": null,
+                        "crop_width": null,
+                        "crop_height": null,
+                        "crop_unit": "pixel"
+                     },
+                     "additional_device_names": null,
+                     "light_sources": [
+                        {
+                           "object_type": "Laser config",
+                           "device_name": "Ex_445",
+                           "wavelength": 445,
+                           "wavelength_unit": "nanometer",
+                           "power": 20.0,
+                           "power_unit": "percent",
+                           "power_measured_at": null
+                        }
+                     ],
+                     "variable_power": false,
+                     "excitation_filters": null,
+                     "emission_filters": [
+                        {
+                           "object_type": "Device config",
+                           "device_name": "Em_469"
+                        }
+                     ],
+                     "emission_wavelength": 469,
+                     "emission_wavelength_unit": "nanometer"
+                  },
+                  {
+                     "object_type": "Channel",
+                     "channel_name": "Ex_561_Em_600_left",
+                     "intended_measurement": null,
+                     "detector": {
+                        "object_type": "Detector config",
+                        "device_name": "Camera",
+                        "exposure_time": null,
+                        "exposure_time_unit": "millisecond",
+                        "trigger_type": "Internal",
+                        "compression": null,
+                        "crop_offset_x": null,
+                        "crop_offset_y": null,
+                        "crop_width": null,
+                        "crop_height": null,
+                        "crop_unit": "pixel"
+                     },
+                     "additional_device_names": null,
+                     "light_sources": [
+                        {
+                           "object_type": "Laser config",
+                           "device_name": "Ex_561",
+                           "wavelength": 561,
+                           "wavelength_unit": "nanometer",
+                           "power": 54.55,
+                           "power_unit": "percent",
+                           "power_measured_at": null
+                        }
+                     ],
+                     "variable_power": false,
+                     "excitation_filters": null,
+                     "emission_filters": [
+                        {
+                           "object_type": "Device config",
+                           "device_name": "Em_600"
+                        }
+                     ],
+                     "emission_wavelength": 600,
+                     "emission_wavelength_unit": "nanometer"
+                  }
+               ],
+               "coordinate_system": {
+                  "object_type": "Coordinate system",
+                  "name": "SPIM_RPI",
+                  "origin": "Origin",
+                  "axes": [
+                     {
+                        "object_type": "Axis",
+                        "name": "X",
+                        "direction": "Left_to_right"
+                     },
+                     {
+                        "object_type": "Axis",
+                        "name": "Y",
+                        "direction": "Anterior_to_posterior"
+                     },
+                     {
+                        "object_type": "Axis",
+                        "name": "Z",
+                        "direction": "Superior_to_inferior"
+                     }
+                  ],
+                  "axis_unit": "millimeter"
+               },
+               "images": [
+                  {
+                     "object_type": "Image spim",
+                     "channel_name": "Ex_445_Em_469_left",
+                     "dimensions_unit": "pixel",
+                     "image_to_acquisition_transform": [
+                        {
+                           "object_type": "Scale",
+                           "scale": [
+                              1.8,
+                              1.8,
+                              2.0
+                           ]
+                        },
+                        {
+                           "object_type": "Translation",
+                           "translation": [
+                              43238.0,
+                              50434.0,
+                              97.7
+                           ]
+                        }
+                     ],
+                     "dimensions": null,
+                     "file_name": "SPIM/Ex_445_Em_469/432380_504340.ome.zarr",
+                     "imaging_angle": 0,
+                     "imaging_angle_unit": "degrees",
+                     "image_start_time": null,
+                     "image_end_time": null
+                  },
+                  {
+                     "object_type": "Image spim",
+                     "channel_name": "Ex_445_Em_469_left",
+                     "dimensions_unit": "pixel",
+                     "image_to_acquisition_transform": [
+                        {
+                           "object_type": "Scale",
+                           "scale": [
+                              1.8,
+                              1.8,
+                              2.0
+                           ]
+                        },
+                        {
+                           "object_type": "Translation",
+                           "translation": [
+                              43238.0,
+                              53026.0,
+                              97.7
+                           ]
+                        }
+                     ],
+                     "dimensions": null,
+                     "file_name": "SPIM/Ex_445_Em_469/432380_530260.ome.zarr",
+                     "imaging_angle": 0,
+                     "imaging_angle_unit": "degrees",
+                     "image_start_time": null,
+                     "image_end_time": null
+                  },
+                  {
+                     "object_type": "Image spim",
+                     "channel_name": "Ex_445_Em_469_left",
+                     "dimensions_unit": "pixel",
+                     "image_to_acquisition_transform": [
+                        {
+                           "object_type": "Scale",
+                           "scale": [
+                              1.8,
+                              1.8,
+                              2.0
+                           ]
+                        },
+                        {
+                           "object_type": "Translation",
+                           "translation": [
+                              46478.0,
+                              50434.0,
+                              97.7
+                           ]
+                        }
+                     ],
+                     "dimensions": null,
+                     "file_name": "SPIM/Ex_445_Em_469/464780_504340.ome.zarr",
+                     "imaging_angle": 0,
+                     "imaging_angle_unit": "degrees",
+                     "image_start_time": null,
+                     "image_end_time": null
+                  },
+                  {
+                     "object_type": "Image spim",
+                     "channel_name": "Ex_445_Em_469_left",
+                     "dimensions_unit": "pixel",
+                     "image_to_acquisition_transform": [
+                        {
+                           "object_type": "Scale",
+                           "scale": [
+                              1.8,
+                              1.8,
+                              2.0
+                           ]
+                        },
+                        {
+                           "object_type": "Translation",
+                           "translation": [
+                              46478.0,
+                              53026.0,
+                              97.7
+                           ]
+                        }
+                     ],
+                     "dimensions": null,
+                     "file_name": "SPIM/Ex_445_Em_469/464780_530260.ome.zarr",
+                     "imaging_angle": 0,
+                     "imaging_angle_unit": "degrees",
+                     "image_start_time": null,
+                     "image_end_time": null
+                  },
+                  {
+                     "object_type": "Image spim",
+                     "channel_name": "Ex_561_Em_600_left",
+                     "dimensions_unit": "pixel",
+                     "image_to_acquisition_transform": [
+                        {
+                           "object_type": "Scale",
+                           "scale": [
+                              1.8,
+                              1.8,
+                              2.0
+                           ]
+                        },
+                        {
+                           "object_type": "Translation",
+                           "translation": [
+                              43238.0,
+                              50434.0,
+                              97.7
+                           ]
+                        }
+                     ],
+                     "dimensions": null,
+                     "file_name": "SPIM/Ex_561_Em_600/432380_504340.ome.zarr",
+                     "imaging_angle": 0,
+                     "imaging_angle_unit": "degrees",
+                     "image_start_time": null,
+                     "image_end_time": null
+                  },
+                  {
+                     "object_type": "Image spim",
+                     "channel_name": "Ex_561_Em_600_left",
+                     "dimensions_unit": "pixel",
+                     "image_to_acquisition_transform": [
+                        {
+                           "object_type": "Scale",
+                           "scale": [
+                              1.8,
+                              1.8,
+                              2.0
+                           ]
+                        },
+                        {
+                           "object_type": "Translation",
+                           "translation": [
+                              43238.0,
+                              53026.0,
+                              97.7
+                           ]
+                        }
+                     ],
+                     "dimensions": null,
+                     "file_name": "SPIM/Ex_561_Em_600/432380_530260.ome.zarr",
+                     "imaging_angle": 0,
+                     "imaging_angle_unit": "degrees",
+                     "image_start_time": null,
+                     "image_end_time": null
+                  },
+                  {
+                     "object_type": "Image spim",
+                     "channel_name": "Ex_561_Em_600_left",
+                     "dimensions_unit": "pixel",
+                     "image_to_acquisition_transform": [
+                        {
+                           "object_type": "Scale",
+                           "scale": [
+                              1.8,
+                              1.8,
+                              2.0
+                           ]
+                        },
+                        {
+                           "object_type": "Translation",
+                           "translation": [
+                              46478.0,
+                              50434.0,
+                              97.7
+                           ]
+                        }
+                     ],
+                     "dimensions": null,
+                     "file_name": "SPIM/Ex_561_Em_600/464780_504340.ome.zarr",
+                     "imaging_angle": 0,
+                     "imaging_angle_unit": "degrees",
+                     "image_start_time": null,
+                     "image_end_time": null
+                  },
+                  {
+                     "object_type": "Image spim",
+                     "channel_name": "Ex_561_Em_600_left",
+                     "dimensions_unit": "pixel",
+                     "image_to_acquisition_transform": [
+                        {
+                           "object_type": "Scale",
+                           "scale": [
+                              1.8,
+                              1.8,
+                              2.0
+                           ]
+                        },
+                        {
+                           "object_type": "Translation",
+                           "translation": [
+                              46478.0,
+                              53026.0,
+                              97.7
+                           ]
+                        }
+                     ],
+                     "dimensions": null,
+                     "file_name": "SPIM/Ex_561_Em_600/464780_530260.ome.zarr",
+                     "imaging_angle": 0,
+                     "imaging_angle_unit": "degrees",
+                     "image_start_time": null,
+                     "image_end_time": null
+                  }
+               ],
+               "sampling_strategy": null
+            },
+            {
+               "object_type": "Sample chamber config",
+               "device_name": "Sample Chamber",
+               "chamber_immersion": {
+                  "object_type": "Immersion",
+                  "medium": "oil",
+                  "refractive_index": 1.522
+               },
+               "sample_immersion": {
+                  "object_type": "Immersion",
+                  "medium": "easy index",
+                  "refractive_index": 1.5199
+               }
+            }
+         ],
+         "connections": []
       }
-   ]
+   ],
+   "stimulus_epochs": [],
+   "manipulations": [],
+   "subject_details": null
 }

--- a/tests/test_smartspim_job.py
+++ b/tests/test_smartspim_job.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -77,6 +78,27 @@ class SmartspimCompressionTest(unittest.TestCase):
         acq_path = DATA_DIR / "acquisition.json"
         voxel_res = self.basic_job._get_voxel_resolution(acq_path)
         expected_res = [2.0, 1.8, 1.8]
+        self.assertEqual(expected_res, voxel_res)
+
+    def test_get_voxel_resolution_legacy(self):
+        """Tests _get_voxel_resolution reads the legacy (pre-v2) schema"""
+        legacy = {
+            "schema_version": "0.4.6",
+            "tiles": [
+                {
+                    "coordinate_transformations": [
+                        {"type": "translation", "translation": [1, 2, 3]},
+                        {"type": "scale", "scale": [1.8, 1.8, 2.0]},
+                    ]
+                }
+            ],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            acq_path = Path(tmp) / "acquisition.json"
+            with open(acq_path, "w") as f:
+                json.dump(legacy, f)
+            voxel_res = self.basic_job._get_voxel_resolution(acq_path)
+        expected_res = [2.0, 1.8, 1.8]  # (z, y, x)
         self.assertEqual(expected_res, voxel_res)
 
     def test_get_voxel_resolution_error(self):


### PR DESCRIPTION
> [!IMPORTANT]
> This work was done almost entirely by an LLM agent. Reviewers should keep that in mind and scrutinize these changes appropriately.

## Summary

Fixes an incompatibility introduced when `aind-smartspim-operator-utils` migrated
its `acquisition.json` producer to **aind-data-schema v2**. The v2 schema replaced
the flat `tiles[]` list (each carrying `coordinate_transformations`) with a nested
`data_streams -> DataStream -> ImagingConfig -> images (ImageSPIM)` structure, so
`SmartspimCompressionJob._get_voxel_resolution` could no longer find the voxel
scale.

Note this repo does **not** import `aind-data-schema` — it reads `acquisition.json`
as a plain dict — so this was purely a data-shape break, isolated to that one
method.

## Changes

- **`_get_voxel_resolution`** now walks the v2 layout
  (`data_streams -> configurations -> images -> image_to_acquisition_transform -> Scale`)
  and reads the `Scale` transform of the first image (all tiles share one
  resolution). Same return contract (`[z, y, x]`, `FileNotFoundError` on missing
  file); raises `ValueError` if no image/transform is found.
- **Regenerated the test fixture** `tests/resources/.../acquisition.json` in v2
  format using `make_acquisition`'s `build_imaging_config` / `build_acquisition`
  helpers, keeping the same channels, tile grid, and `[1.8, 1.8, 2.0]` voxel scale.
  The expected voxel resolution stays `[2.0, 1.8, 1.8]`, so no test assertions
  changed.

## Testing caveats

⚠️ The full suite (11 tests, including `test_integration`, which runs
`run_job -> _write_stacks -> _get_voxel_resolution` and writes zarr) **passed
locally**, but **not in a pin-exact environment**. It was run in a conda env
(Python 3.11 / arm64) where several of this repo's pinned dependencies could not
be built or resolved, so working substitutes were used:

- `numcodecs 0.13.1` instead of the pinned `0.11.0` (0.11.0 fails to compile on
  py3.11/arm64; 0.13.1 ships prebuilt wheels and still exposes the `cbuffer_sizes`
  API that `zarr` 2.x requires)
- `zarr 2.18.2` and `ome-zarr 0.8.2` (pinned versions, after pip initially pulled
  in incompatible 3.x releases)
- `aind-data-transformation`, `dask`, `dask-image`, `pims`, `xarray-multiscale`,
  `scikit-image` installed **unpinned**
- `s3fs` was incidentally upgraded `0.4.2 -> 2026.6.0`

The core logic was also verified independently of the zarr/dask stack. **Please
re-run `coverage run -m unittest discover && coverage report` in a pin-exact
environment (or CI) to confirm before merging.**
